### PR TITLE
add ability to trigger alerts on success

### DIFF
--- a/lib/forms/controllers/forms.js
+++ b/lib/forms/controllers/forms.js
@@ -135,7 +135,7 @@ exports.submitFormData = function(req, res) {
 
 exports.submitFormDataAlert = function(req, res) {
   logData(req.body);
-  res.render(VIEWS_DIR + req.body.bioid,{triggerAlert:true, bioid: bioid});
+  res.render(VIEWS_DIR + req.body.bioid,{triggerAlert:true, bioId: req.body.bioid});
 };
 
 exports.renderImage = function(req, res) {

--- a/lib/forms/controllers/forms.js
+++ b/lib/forms/controllers/forms.js
@@ -133,6 +133,11 @@ exports.submitFormData = function(req, res) {
   res.render(VIEWS_DIR + 'success');
 };
 
+exports.submitFormDataAlert = function(req, res) {
+  logData(req.body);
+  res.render(VIEWS_DIR + req.body.bioid,{triggerAlert:true, bioid: bioid});
+};
+
 exports.renderImage = function(req, res) {
   var remainder = (new Date().getTime()) % 6;
   var imgPath = path.join(__dirname + '/../images/captcha.jpg');

--- a/lib/forms/forms.js
+++ b/lib/forms/forms.js
@@ -40,4 +40,5 @@ app.post('/postData', exports.callbacks.deletePostData);
 app.get('/images', exports.callbacks.renderImage);
 app.get('/:bioId', exports.callbacks.getCongressForm);
 app.post('/submitFormData', exports.callbacks.submitFormData);
+app.post('/submitFormDataAlert', exports.callbacks.submitFormDataAlert);
 

--- a/lib/forms/views/MNL000002.jade
+++ b/lib/forms/views/MNL000002.jade
@@ -2,7 +2,9 @@ extends layout
 
 block content
 
-  form(method='POST', action='/forms/submitFormData', role="form")
+  include triggerAlert
+
+  form(method='POST', action='/forms/submitFormDataAlert', role="form")
     .row
 
       br

--- a/lib/forms/views/triggerAlert.jade
+++ b/lib/forms/views/triggerAlert.jade
@@ -1,0 +1,4 @@
+if triggerAlert
+   script(type='text/javascript').
+      alert('Success!');
+


### PR DESCRIPTION
By adding the following to a view, it will return to itself and trigger an alert that contains: `Success!`
```jade
include triggerAlert

form(method='POST', action='/forms/submitFormDataAlert', role="form")
```
Note the action value.

There must also be an input present with `name='bioid'` and value of this input must match the view name.
```jade
input(type='text' id='bioid' name='bioid' value='#{bioId}')
```
I recommend using that line exactly as is ^
